### PR TITLE
Add plone4.csrffixes.

### DIFF
--- a/hotfixes.js
+++ b/hotfixes.js
@@ -1,6 +1,13 @@
 
 var hotfixes = {
 
+  "plone4.csrffixes": {
+    "required_for_plone": [
+        ["4", "4.99.??"]
+    ],
+    "fixed_in_plone": ["5.0a1"],
+    "plone.org": "https://plone.org/products/plone-hotfix/releases/20151006"},
+
   "Products.PloneHotfix20150910": {
     "required_for_plone": [
         ["1.0", "4.3.6"],

--- a/test/test_hotfixes.js
+++ b/test/test_hotfixes.js
@@ -46,6 +46,33 @@ function assert_hotfixes_not_required_by(plone_versions, hotfix) {
 /* ************************ */
 
 
+describe('plone4.csrffixes', function() {
+  it('should be required for all current Plone versions.', function() {
+    assert_hotfixes_required_by(
+        ["4.0", "4.0", "4.0.1", "4.0.10", "4.0.2", "4.0.3", "4.0.4", "4.0.5", "4.0.6", "4.0.6.1", "4.0.7", "4.0.8", "4.0.9",
+         "4.1", "4.1", "4.1.1", "4.1.2", "4.1.3", "4.1.4", "4.1.5", "4.1.6",
+         "4.2", "4.2", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7",
+         "4.3", "4.3", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3.7", "4.3a1", "4.3a2", "4.3b1", "4.3b2"],
+        "plone4.csrffixes");
+  });
+
+  it('should does not work with versions older than 4', function() {
+    assert_hotfixes_not_required_by(
+          ["1.0",
+           "2.0",
+           "3.2", "3.2.1", "3.2.2", "3.2.3",
+           "3.3", "3.3", "3.3.1", "3.3.2", "3.3.3", "3.3.4", "3.3.5", "3.3.6"],
+        "plone4.csrffixes");
+  });
+
+  it('should is not necessary for Plone 5 versions', function() {
+    assert_hotfixes_not_required_by(
+        ["5.0a1", "5.0b1", "5.0rc1", "5.0"],
+        "plone4.csrffixes");
+  });
+});
+
+
 describe('Products.PloneHotfix20150910', function() {
   it('should be required for all current Plone versions.', function() {
     assert_hotfixes_required_by(

--- a/test/test_plone_versions.js
+++ b/test/test_plone_versions.js
@@ -99,6 +99,7 @@ describe("Plone 4.0", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -122,6 +123,7 @@ describe("Plone 4.0.9", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -143,6 +145,7 @@ describe("Plone 4.0.10", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -161,6 +164,7 @@ describe("Plone 4.1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -181,6 +185,7 @@ describe("Plone 4.1.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -199,6 +204,7 @@ describe("Plone 4.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -218,6 +224,7 @@ describe("Plone 4.2.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618",
@@ -237,6 +244,7 @@ describe("Plone 4.2.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618"
@@ -254,6 +262,7 @@ describe("Plone 4.2.5", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618"
@@ -270,6 +279,7 @@ describe("Plone 4.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910",
             "Products.PloneHotfix20131210",
             "Products.PloneHotfix20130618"
@@ -286,6 +296,7 @@ describe("Plone 4.3.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes",
             "Products.PloneHotfix20150910"
         ],
         "4.3.6");
@@ -300,12 +311,26 @@ describe("Plone 4.3.7", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "plone4.csrffixes"
         ],
         "4.3.7");
   });
 
 });
 
+
+
+describe("Plone 5.0a1", function() {
+
+  it('should require fixes', function() {
+    assertRequires(
+        [
+            "Products.PloneHotfix20150910"
+        ],
+        "5.0a1");
+  });
+
+});
 
 
 describe("Plone 5.0rc1", function() {


### PR DESCRIPTION
Add plone4.csrffixes.
- https://plone.org/products/plone/security/advisories/20151006-preannouncement
- https://plone.org/products/plone-hotfix/releases/20151006
- https://pypi.python.org/pypi/plone4.csrffixes

Affected Versions:
- Plone < 4 (1.x, 2.x, 3.x): affected but patch does not apply
- Plone 4.x: affected and patch applies to all currently released versions
- Plone 5.x: not affected, patch is not necessary.
