### PR TITLE
add Products.PloneHotfix20160419

### DIFF
--- a/hotfixes.js
+++ b/hotfixes.js
@@ -6,7 +6,7 @@ var hotfixes = {
           ["4", "4.3.9"],
           ["5.0a1", "5.1a1"]
     ],
-    "fixed_in_plone": [],
+    "fixed_in_plone": ["4.3.10", "5.0.5"],
     "plone.org": "https://plone.org/products/plone/security/advisories/20160419-preannounce"},
 
   "plone4.csrffixes": {

--- a/hotfixes.js
+++ b/hotfixes.js
@@ -1,6 +1,14 @@
 
 var hotfixes = {
 
+  "Products.PloneHotfix20160419": {
+    "required_for_plone": [
+          ["4", "4.3.9"],
+          ["5.0a1", "5.1a1"]
+    ],
+    "fixed_in_plone": [],
+    "plone.org": "https://plone.org/products/plone/security/advisories/20160419-preannounce"},
+
   "plone4.csrffixes": {
     "required_for_plone": [
         ["4", "4.99.??"]

--- a/test/test_hotfixes.js
+++ b/test/test_hotfixes.js
@@ -46,6 +46,36 @@ function assert_hotfixes_not_required_by(plone_versions, hotfix) {
 /* ************************ */
 
 
+describe('Products.PloneHotfix20160419', function() {
+  it('should be required for all current Plone versions.', function() {
+    assert_hotfixes_required_by(
+          ["4.0", "4.0", "4.0.1", "4.0.10", "4.0.2", "4.0.3", "4.0.4", "4.0.5", "4.0.6", "4.0.6.1", "4.0.7", "4.0.8", "4.0.9",
+           "4.1", "4.1", "4.1.1", "4.1.2", "4.1.3", "4.1.4", "4.1.5", "4.1.6",
+           "4.2", "4.2", "4.2.1", "4.2.2", "4.2.3", "4.2.4", "4.2.5", "4.2.6", "4.2.7",
+           "4.3", "4.3", "4.3.1", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3a1", "4.3a2", "4.3b1", "4.3b2",
+           "5.0rc1",
+           "5.0rc2",
+           "5.0",
+           "5.0.1",
+           "5.0.2",
+           "5.0.3",
+           "5.0.4",
+           "5.1a1"
+          ],
+          "Products.PloneHotfix20160419");
+  });
+
+  it('is not tested for older Plone versions and thus not proposed.', function() {
+    assert_hotfixes_not_required_by(
+          ["1.0",
+           "2.0",
+           "3.2", "3.2.1", "3.2.2", "3.2.3",
+           "3.3", "3.3", "3.3.1", "3.3.2", "3.3.3", "3.3.4", "3.3.5", "3.3.6"],
+        "Products.PloneHotfix20160419");
+  });
+});
+
+
 describe('plone4.csrffixes', function() {
   it('should be required for all current Plone versions.', function() {
     assert_hotfixes_required_by(

--- a/test/test_plone_versions.js
+++ b/test/test_plone_versions.js
@@ -103,6 +103,7 @@ describe("Plone 4.0", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -128,6 +129,7 @@ describe("Plone 4.0.9", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -151,6 +153,7 @@ describe("Plone 4.0.10", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -171,6 +174,7 @@ describe("Plone 4.1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -193,6 +197,7 @@ describe("Plone 4.1.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -213,6 +218,7 @@ describe("Plone 4.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -234,6 +240,7 @@ describe("Plone 4.2.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -255,6 +262,7 @@ describe("Plone 4.2.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -274,6 +282,7 @@ describe("Plone 4.2.5", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -292,6 +301,7 @@ describe("Plone 4.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910",
@@ -310,6 +320,7 @@ describe("Plone 4.3.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910"
@@ -326,6 +337,7 @@ describe("Plone 4.3.7", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes",
             "Products.PloneHotfix20151208"
         ],
@@ -341,6 +353,7 @@ describe("Plone 4.3.8", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes"
         ],
         "4.3.8");
@@ -355,6 +368,7 @@ describe("Plone 4.3.9", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "plone4.csrffixes"
         ],
         "4.3.9");
@@ -369,6 +383,7 @@ describe("Plone 5.0a1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910"
         ],
@@ -383,6 +398,7 @@ describe("Plone 5.0rc1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208",
             "Products.PloneHotfix20150910"
         ],
@@ -398,6 +414,7 @@ describe("Plone 5.0rc2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208"
         ],
         "5.0rc2");
@@ -412,6 +429,7 @@ describe("Plone 5.0", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208"
         ],
         "5.0");
@@ -425,6 +443,7 @@ describe("Plone 5.0.1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419"
         ],
         "5.0.1");
   });
@@ -437,6 +456,7 @@ describe("Plone 5.0.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419"
         ],
         "5.0.2");
   });
@@ -449,6 +469,7 @@ describe("Plone 5.0.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419"
         ],
         "5.0.3");
   });
@@ -461,6 +482,7 @@ describe("Plone 5.0.4", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419"
         ],
         "5.0.4");
   });
@@ -473,6 +495,7 @@ describe("Plone 5.1a1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20160419"
         ],
         "5.1a1");
   });


### PR DESCRIPTION
🚧 Wait for patch to be released 🚧 

According to
https://plone.org/products/plone/security/advisories/20160419-preannounce

It says:

> Versions Affected: All supported Plone versions (4.x, 5.x). Previous
> versions could be affected but have not been tested.

Therefore we propose installation for all currently released 5.x and 5.x
versions but not older versions (3.x, 2.x, 1.x).

@maethu @buchi do you agree?
