### PR TITLE
🚧  Prepare for Products.PloneHotfix20161129

### DIFF
--- a/hotfixes.js
+++ b/hotfixes.js
@@ -1,6 +1,14 @@
 
 var hotfixes = {
 
+  "Products.PloneHotfix20161129": {
+    "required_for_plone": [
+          ["4", "4.99.??"],
+          ["5", "5.99.??"]
+    ],
+    "fixed_in_plone": [],
+    "plone.org": "https://plone.org/security/hotfix/20161129"},
+
   "Products.PloneHotfix20160830": {
     "required_for_plone": [
           ["3", "3.99.??"],

--- a/test/test_plone_versions.js
+++ b/test/test_plone_versions.js
@@ -107,6 +107,7 @@ describe("Plone 4.0", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -134,6 +135,7 @@ describe("Plone 4.0.9", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -159,6 +161,7 @@ describe("Plone 4.0.10", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -181,6 +184,7 @@ describe("Plone 4.1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -205,6 +209,7 @@ describe("Plone 4.1.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -227,6 +232,7 @@ describe("Plone 4.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -250,6 +256,7 @@ describe("Plone 4.2.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -273,6 +280,7 @@ describe("Plone 4.2.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -294,6 +302,7 @@ describe("Plone 4.2.5", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -314,6 +323,7 @@ describe("Plone 4.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -334,6 +344,7 @@ describe("Plone 4.3.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -352,6 +363,7 @@ describe("Plone 4.3.7", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes",
@@ -369,6 +381,7 @@ describe("Plone 4.3.8", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes"
@@ -385,6 +398,7 @@ describe("Plone 4.3.9", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "plone4.csrffixes"
@@ -400,6 +414,7 @@ describe("Plone 4.3.10", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "plone4.csrffixes"
         ],
@@ -414,6 +429,7 @@ describe("Plone 5.0a1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208",
@@ -430,6 +446,7 @@ describe("Plone 5.0rc1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208",
@@ -447,6 +464,7 @@ describe("Plone 5.0rc2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208"
@@ -463,6 +481,7 @@ describe("Plone 5.0rc3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208"
@@ -479,6 +498,7 @@ describe("Plone 5.0", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419",
             "Products.PloneHotfix20151208"
@@ -494,6 +514,7 @@ describe("Plone 5.0.1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419"
         ],
@@ -508,6 +529,7 @@ describe("Plone 5.0.2", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419"
         ],
@@ -522,6 +544,7 @@ describe("Plone 5.0.3", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419"
         ],
@@ -536,6 +559,7 @@ describe("Plone 5.0.4", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419"
         ],
@@ -550,6 +574,7 @@ describe("Plone 5.0.5", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830"
         ],
         "5.0.5");
@@ -563,6 +588,7 @@ describe("Plone 5.0.6", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830"
         ],
         "5.0.6");
@@ -576,6 +602,7 @@ describe("Plone 5.1a1", function() {
   it('should require fixes', function() {
     assertRequires(
         [
+            "Products.PloneHotfix20161129",
             "Products.PloneHotfix20160830",
             "Products.PloneHotfix20160419"
         ],


### PR DESCRIPTION
Prepare for the upcoming hotfix:
- https://plone.org/security/announcements/20161129-preannounce
- Products.PloneHotfix20161129
- Scheduled for 2016-11-29 15:00 UTC 

🚧 🚧 🚧  Should be merged at **2016-11-29 15:00 UTC** when the hotfix is released 🚧 🚧 🚧