### PR TITLE
Fix versions including Products.PloneHotfix20171128

### DIFF
--- a/hotfixes.js
+++ b/hotfixes.js
@@ -4,12 +4,14 @@ var hotfixes = {
   "Products.PloneHotfix20171128": {
     "required_for_plone": [
           ["3", "3.99.??"],
-          ["4", "4.3.16"],
-          ["5", "5.1rc1"]
+          ["4", "4.3.15"],
+          ["5", "5.0.9"],
+          ["5.1a1", "5.1.0"]
     ],
     "fixed_in_plone": [
-          "4.3.17",
-          "5.2a1"
+          "4.3.16",
+          "5.0.10",
+          "5.1.0.1"
     ],
     "plone.org": "https://plone.org/security/hotfix/20171128"},
 

--- a/test/test_plone_versions.js
+++ b/test/test_plone_versions.js
@@ -467,7 +467,6 @@ describe("Plone 4.3.16", function() {
   it('should require fixes', function() {
     assertRequires(
         [
-            "Products.PloneHotfix20171128",
             "plone4.csrffixes"
         ],
         "4.3.16");
@@ -679,6 +678,31 @@ describe("Plone 5.0.6", function() {
             "Products.PloneHotfix20160830"
         ],
         "5.0.6");
+  });
+
+});
+
+
+describe("Plone 5.0.9", function() {
+
+  it('should require fixes', function() {
+    assertRequires(
+        [
+            "Products.PloneHotfix20171128",
+        ],
+        "5.0.9");
+  });
+
+});
+
+
+describe("Plone 5.0.10", function() {
+
+  it('should require fixes', function() {
+    assertRequires(
+        [
+        ],
+        "5.0.10");
   });
 
 });


### PR DESCRIPTION
The configuration of affected Plone versions for the hotfix Products.PloneHotfix20171128 was wrong: the fix was already present in earlier versions.

The changes are according to https://plone.org/security/hotfixes

Source discussion: https://github.com/4teamwork/ftw-buildouts/pull/166#discussion_r344208001